### PR TITLE
Creates the song row right away and only updates the song length later

### DIFF
--- a/scripts/album.js
+++ b/scripts/album.js
@@ -1,12 +1,12 @@
 
 
-var createSongRow = function(songNumber, songName, songLength) {
+var createSongRow = function(songNumber, songName) {
      
        var template =
         '<tr class="album-view-song-item">'
       + '  <td class="song-item-number" data-song-number="' + songNumber + '">' + songNumber + '</td>'
       + '  <td class="song-item-title">' + songName + '</td>'
-      + '  <td class="song-item-duration">' + filterTimeCode(songLength) + '</td>'
+      + '  <td class="song-item-duration"></td>'
       + '</tr>'
       ;
  
@@ -87,11 +87,12 @@ var setCurrentAlbum = function(album) {
      for (i = 0; i < album.songs.length; i++) {
         var sound = new buzz.sound(album.songs[i].audioUrl, {  formats: [ 'mp3' ],   preload: 'metadata'  });
          var mySound = function(i,sound){
+            var $newRow = createSongRow(i + 1, album.songs[i].name);
+            $albumSongList.append($newRow);
             return function(){
                 var length = sound.getDuration();
                 currentSongDurations.push(length);
-                var $newRow = createSongRow(i + 1, album.songs[i].name, length);
-                $albumSongList.append($newRow);
+                $newRow.find('.song-item-duration').text(filterTimeCode(length));
             }
         };
         sound.bind("loadedmetadata", mySound(i,sound));


### PR DESCRIPTION
Hi Eric. Here's a fix that will ensure the track listing is always in the right order.

To make sure that the total song length shown in the player bar is the correct one, you could:
- update the fixtures with the correct values once you know them,
- keep the song length in a `data-` attribute in your HTML,
- or just ask buzz again for the song length

The first option is probably the easiest.
